### PR TITLE
Using screenX, screenY instead of pageX, pageY for transform calculation

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -69,8 +69,8 @@ class Zoom extends Component {
       },
     } = this.imageRef
 
-    const x = ((e.pageX - offsetLeft) / parseInt(width, 10)) * 100
-    const y = ((e.pageY - offsetTop) / parseInt(height, 10)) * 100
+    const x = ((e.screenX - offsetLeft) / parseInt(width, 10)) * 100
+    const y = ((e.screenY - offsetTop) / parseInt(height, 10)) * 100
 
     this.setState({
       mouseX: x,


### PR DESCRIPTION
Changed This:
`const x = ((e.pageX - offsetLeft) / parseInt(width, 10)) * 100
 const y = ((e.pageY - offsetTop) / parseInt(height, 10)) * 100`
 To This:
`const x = ((e.screenX - offsetLeft) / parseInt(width, 10)) * 100
 const y = ((e.screenY - offsetTop) / parseInt(height, 10)) * 100`
 
 Because, when we use multiple react-img-zoom components on the same page, the behavior of the component changes as the page height increases. We don't want that. We want the behavior to stay the same for all the components. So using screen value instead of page value to make sure it stays the same. 